### PR TITLE
Use Services global variable if possible

### DIFF
--- a/api/Utilities/implementation.js
+++ b/api/Utilities/implementation.js
@@ -12,7 +12,9 @@
  /* eslint-disable object-shorthand */
 
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 var {NetUtil} =   ChromeUtils.import("resource://gre/modules/NetUtil.jsm");
 
 function getImageData(src) {

--- a/api/customui/parent.js
+++ b/api/customui/parent.js
@@ -1,8 +1,9 @@
 var ex_customui = class extends ExtensionCommon.ExtensionAPI {
   getAPI(context) {
     const Cc = Components.classes;
-    const { Services } = ChromeUtils.import(
-        "resource://gre/modules/Services.jsm");
+    const Services = globalThis.Services || ChromeUtils.import(
+      "resource://gre/modules/Services.jsm"
+    ).Services;
     const { ExtensionParent } = ChromeUtils.import(
         "resource://gre/modules/ExtensionParent.jsm");
     const { setTimeout } = ChromeUtils.import(


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm for recent versions.